### PR TITLE
Remove global include

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    human_attribute_values (1.2.1)
+    human_attribute_values (1.2.2)
       rails (>= 4.2.10)
 
 GEM
@@ -135,7 +135,7 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.4.0)
+    zeitwerk (2.4.1)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -14,8 +14,37 @@ gem install human_attribute_values
   * Ruby: MRI >= 2.3.0
 
 ## Usage
-The gem defines ``human_attribute_value`` as instance and class method on ``ActiveRecord::Base`` and ``ActiveModel::Model``.
-To translate a value it uses the I18n API. The translations are looked up from the current locale file under the key ``'activerecord.values.model_name.attribute_name.value'`` respectively ``'activemodel.values.model_name.attribute_name.value'`` by default.
+
+The module `HumanAttributeValues` defines `human_attribute_value` as both an instance and class method.
+
+
+### ActiveRecord
+
+You can include the module in any specific models you wish to translate directly, or include it in `ApplicationRecord` globally.
+
+```ruby
+class ApplicationRecord < ActiveRecord::Base
+  include HumanAttributeValues
+  self.abstract_class = true
+end
+```
+
+To translate a value it uses the I18n API. The translations are looked up from the current locale file under the key `'activerecord.values.{model_name}.attribute_name.value'` by default.
+
+### ActiveModel
+
+You can include the module in any specific models you wish to translate directly, or include it in `ApplicationRecord` globally.
+
+```ruby
+class Model
+  include ActiveModel::Model
+  include HumanAttributeValues
+
+  attr_accessor ...
+end
+```
+
+To translate a value it uses the I18n API. The translations are looked up from the current locale file under the key `'activemodel.values.{model_name}.attribute_name.value'` by default.
 
 ### Locale:
 ```yml

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ gem install human_attribute_values
 
 The module `HumanAttributeValues` defines `human_attribute_value` as both an instance and class method.
 
-
 ### ActiveRecord
 
 You can include the module in any specific models you wish to translate directly, or include it in `ApplicationRecord` globally.

--- a/lib/human_attribute_values/human_attribute_value.rb
+++ b/lib/human_attribute_values/human_attribute_value.rb
@@ -41,6 +41,3 @@ module HumanAttributeValues
     end
   end
 end
-
-ActiveRecord::Base.include HumanAttributeValues
-ActiveModel::Model.include HumanAttributeValues

--- a/test/dummy/app/models/active_model_model.rb
+++ b/test/dummy/app/models/active_model_model.rb
@@ -2,6 +2,7 @@
 
 class ActiveModelModel
   include ActiveModel::Model
+  include HumanAttributeValues
 
   attr_accessor :boolean_attr, :decimal_attr, :integer_attr, :float_attr, :string_attr
 end

--- a/test/dummy/app/models/active_model_parent.rb
+++ b/test/dummy/app/models/active_model_parent.rb
@@ -2,6 +2,7 @@
 
 class ActiveModelParent
   include ActiveModel::Model
+  include HumanAttributeValues
 
   attr_accessor :inherited_attr
 end

--- a/test/dummy/app/models/application_record.rb
+++ b/test/dummy/app/models/application_record.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ApplicationRecord < ActiveRecord::Base
+  include HumanAttributeValues
+
+  self.abstract_class = true
+end

--- a/test/dummy/app/models/boolean_model.rb
+++ b/test/dummy/app/models/boolean_model.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class BooleanModel < ActiveRecord::Base
+class BooleanModel < ApplicationRecord
 end

--- a/test/dummy/app/models/enum_model.rb
+++ b/test/dummy/app/models/enum_model.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class EnumModel < ActiveRecord::Base
+class EnumModel < ApplicationRecord
   enum status: {dead_and_alive: 0, alive: 1, dead: 2}
 end

--- a/test/dummy/app/models/lexicon.rb
+++ b/test/dummy/app/models/lexicon.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class Lexicon < ActiveRecord::Base
+class Lexicon < ApplicationRecord
   has_many :the_answers
 end

--- a/test/dummy/app/models/numeric_model.rb
+++ b/test/dummy/app/models/numeric_model.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class NumericModel < ActiveRecord::Base
+class NumericModel < ApplicationRecord
 end

--- a/test/dummy/app/models/parent.rb
+++ b/test/dummy/app/models/parent.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class Parent < ActiveRecord::Base
+class Parent < ApplicationRecord
 end

--- a/test/dummy/app/models/the_answer.rb
+++ b/test/dummy/app/models/the_answer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class TheAnswer < ActiveRecord::Base
+class TheAnswer < ApplicationRecord
   belongs_to :lexicon
 end


### PR DESCRIPTION
Per #10, this would allow users to include the module however they like, avoiding forced global inclusion.

This change would probably require a 2.0.0 version bump.